### PR TITLE
test: move pr2 periodicaly in rostest

### DIFF
--- a/rostest/data_collection.test
+++ b/rostest/data_collection.test
@@ -5,6 +5,7 @@
   </include>
 
   <node pkg="mohou_ros" type="random_image_publisher.py" name="random_image_publisher"/>
+  <node pkg="mohou_ros" type="periodic_pr2_controller.py" name="random_pr2_controller"/>
 
   <test pkg="mohou_ros" type="run_data_collection.py" test-name="data_collection" time-limit="600"/>
 </launch>

--- a/rostest/node_script/periodic_pr2_controller.py
+++ b/rostest/node_script/periodic_pr2_controller.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import time
+
+import rospy
+import skrobot
+from skrobot.interfaces.ros import PR2ROSRobotInterface  # type: ignore
+
+
+class NoTrosoPR2(PR2ROSRobotInterface):
+    def default_controller(self):
+        return [self.rarm_controller, self.larm_controller, self.head_controller]
+
+
+robot_model = skrobot.models.PR2()
+ri = NoTrosoPR2(robot_model)
+robot_model.init_pose()
+ri.wait_interpolation()
+
+while not rospy.is_shutdown():
+    robot_model.init_pose()
+    ri.angle_vector(robot_model.angle_vector(), time=2.0, time_scale=1.0)
+    ri.move_gripper("rarm", 0.1, effort=25, wait=False)
+    ri.move_gripper("larm", 0.1, effort=25, wait=False)
+    time.sleep(2)
+
+    robot_model.reset_manip_pose()
+    ri.angle_vector(robot_model.angle_vector(), time=2.0, time_scale=1.0)
+    ri.move_gripper("rarm", 0.0, effort=25, wait=False)
+    ri.move_gripper("larm", 0.0, effort=25, wait=False)
+    time.sleep(2)

--- a/rostest/run_data_collection.py
+++ b/rostest/run_data_collection.py
@@ -57,7 +57,7 @@ class TestNode(unittest.TestCase):
 
     def _test_save_rosbag(self):
         cmd = "rosrun mohou_ros save_rosbag.py -pn {} -t 8".format(self.project_name)
-        n_episode = 3
+        n_episode = 6
         for _ in range(n_episode):
             self._run_command(cmd)
 

--- a/rostest/run_data_collection.py
+++ b/rostest/run_data_collection.py
@@ -57,7 +57,7 @@ class TestNode(unittest.TestCase):
 
     def _test_save_rosbag(self):
         cmd = "rosrun mohou_ros save_rosbag.py -pn {} -t 8".format(self.project_name)
-        n_episode = 6
+        n_episode = 3
         for _ in range(n_episode):
             self._run_command(cmd)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -63,8 +63,9 @@ if __name__ == "__main__":
     project_path = get_project_path(project_name)
     if is_testing:
         # as fast as possible. run only by rostest
+        # note that n_aug_lstm must be required to avoid data generation with small number of samples
         train_and_visualize(
-            project_path, 1, 1, n_hidden=1, n_layer=1, valid_ratio=0.5, n_aug_vae=0, n_aug_lstm=0
+            project_path, 1, 1, n_hidden=1, n_layer=1, valid_ratio=0.5, n_aug_vae=0, n_aug_lstm=4
         )
     else:
         train_and_visualize(project_path, n_epoch_vae, n_epoch_lstm, n_hidden=400, n_layer=2)


### PR DESCRIPTION
Fix https://github.com/HiroIshida/mohou_ros/issues/36
in the data collection phase, originally, pr2's arm and gripper is static. This caused data degeneration, and was the root cause of the SVD error when computing random noise using covariance matrix. To avoid this problem, pr2 is moved periodically in the data collection phase in the rostest. 