### PR TITLE
faet: move baxter by sending euslisp source code directly

### DIFF
--- a/mohou_ros_utils/baxter/params.py
+++ b/mohou_ros_utils/baxter/params.py
@@ -1,0 +1,39 @@
+from typing import List
+
+larm_joint_names = ["left_s0", "left_s1", "left_e0", "left_e1", "left_w0", "left_w1", "left_w2"]
+
+rarm_joint_names = [
+    "right_s0",
+    "right_s1",
+    "right_e0",
+    "right_e1",
+    "right_w0",
+    "right_w1",
+    "right_w2",
+]
+
+larm_controller_name = "l_arm_controller"
+
+rarm_controller_name = "r_arm_controller"
+
+all_controller_names = [larm_controller_name, rarm_controller_name]
+
+
+class BaxterRarmProperty:
+    @property
+    def control_joint_names(self) -> List[str]:
+        return rarm_joint_names
+
+    @property
+    def end_effector_name(self) -> str:
+        return "right_hand"
+
+
+class BaxterLarmProperty:
+    @property
+    def control_joint_names(self) -> List[str]:
+        return larm_joint_names
+
+    @property
+    def end_effector_name(self) -> str:
+        return "left_hand"

--- a/mohou_ros_utils/vive_controller/robot_interface.py
+++ b/mohou_ros_utils/vive_controller/robot_interface.py
@@ -308,12 +308,20 @@ class EuslispBaxterController(EuslispRobotController):
 
 class EuslispBaxterRarmController(BaxterRarmProperty, EuslispBaxterController):
     def move_gripper(self, pos: float) -> None:
-        pass
+        assert pos in [0.0, 1.0]
+        if pos == 0.0:
+            self.proxy("""(send *ri* :start-grasp :rarm)""")
+        else:
+            self.proxy("""(send *ri* :stop-grasp :rarm)""")
 
 
 class EuslispBaxterLarmController(BaxterLarmProperty, EuslispBaxterController):
     def move_gripper(self, pos: float) -> None:
-        pass
+        assert pos in [0.0, 1.0]
+        if pos == 0.0:
+            self.proxy("""(send *ri* :start-grasp :larm)""")
+        else:
+            self.proxy("""(send *ri* :stop-grasp :larm)""")
 
 
 class SkrobotPybulletController(RobotControllerBase):

--- a/mohou_ros_utils/vive_controller/robot_interface.py
+++ b/mohou_ros_utils/vive_controller/robot_interface.py
@@ -255,22 +255,6 @@ class EuslispPR2LarmController(PR2LarmProperty, EuslispPR2Controller):
         return "larm"
 
 
-# (defun baxter-init (&key (safe t) (type :default-controller) (moveit t))
-#   (let (mvit-env mvit-rb)
-#     (when moveit
-#       (setq mvit-env (instance baxter-moveit-environment))
-#       (setq mvit-rb (instance baxter-robot :init)))
-#     (if (not (boundp '*ri*))
-#         (setq *ri* (instance baxter-interface :init :type type
-#                              :moveit-environment mvit-env
-#                              :moveit-robot mvit-rb)))
-#     (if (not (boundp '*baxter*))
-#         (if safe
-#         (setq *baxter* (instance baxter-robot-safe :init))
-#       (setq *baxter* (instance baxter-robot :init))))
-#     (send *ri* :calib-grasp :arms)))
-
-
 class EuslispBaxterController(EuslispRobotController):
     def __init__(self):
         super().__init__()
@@ -282,8 +266,10 @@ class EuslispBaxterController(EuslispRobotController):
     def eus_script_hook(self) -> str:
         script = """
         (load "package://eus_vive/euslisp/lib/baxter-interface.l")
-        (baxter-init)
-        """.format()
+        (baxter-init :type :{arm_name}-controller)
+        """.format(
+            arm_name=self.arm_name()
+        )
         return script
 
     def eus_joint_name_list(self) -> List[str]:
@@ -305,6 +291,10 @@ class EuslispBaxterController(EuslispRobotController):
             "right_w2",
         ]
 
+    @abstractmethod
+    def arm_name(self) -> str:
+        pass
+
 
 class EuslispBaxterRarmController(BaxterRarmProperty, EuslispBaxterController):
     def move_gripper(self, pos: float) -> None:
@@ -314,6 +304,9 @@ class EuslispBaxterRarmController(BaxterRarmProperty, EuslispBaxterController):
         else:
             self.proxy("""(send *ri* :stop-grasp :rarm)""")
 
+    def arm_name(self) -> str:
+        return "rarm"
+
 
 class EuslispBaxterLarmController(BaxterLarmProperty, EuslispBaxterController):
     def move_gripper(self, pos: float) -> None:
@@ -322,6 +315,9 @@ class EuslispBaxterLarmController(BaxterLarmProperty, EuslispBaxterController):
             self.proxy("""(send *ri* :start-grasp :larm)""")
         else:
             self.proxy("""(send *ri* :stop-grasp :larm)""")
+
+    def arm_name(self) -> str:
+        return "larm"
 
 
 class SkrobotPybulletController(RobotControllerBase):


### PR DESCRIPTION
example 
```python
import time

import numpy as np

from mohou_ros_utils.utils import euslisp_unit_to_standard_unit
from mohou_ros_utils.vive_controller.robot_interface import EuslispBaxterRarmController, EuslispBaxterLarmController

cont1 = EuslispBaxterRarmController()
cont2 = EuslispBaxterLarmController()

std_angles_reset_manip_pose = euslisp_unit_to_standard_unit(
    cont1.robot_model,
    cont1.eus_joint_name_list(),
    np.array(
        [0.0, -5.0, -57.0, -68.0, 111.0, 38.0, 59.0, 0.0, 5.0, -57.0, 68.0, 111.0, -38.0, 59.0, 0.0]
    ),
)

std_angles_reset_pose = euslisp_unit_to_standard_unit(
    cont1.robot_model,
    cont1.eus_joint_name_list(),
    np.array(
        [0.0, 20.0, -25.0, -40.0, 60.0, -20.0, 80.0, 0.0, -20.0, -25.0, 40.0, 60.0, 20.0, 80.0, 0.0]
    ),
)

for cont in [cont1, cont2]:
    for joint_name, angle in zip(cont.eus_joint_name_list(), std_angles_reset_manip_pose):
        cont.robot_model.__dict__[joint_name].joint_angle(angle)

cont1.update_real_robot(2)
cont2.update_real_robot(15)

for cont in [cont1, cont2]:
    cont.move_gripper(1.0)
    time.sleep(2)
    cont.move_gripper(0.0)
    time.sleep(2)

```
