### PR TITLE
Prevent relaying init pose

### DIFF
--- a/scripts/pr2/mannequine.py
+++ b/scripts/pr2/mannequine.py
@@ -73,6 +73,7 @@ class Mannequin(object):
         self.enable_mirror = mirror
         self.use_home_position = use_home_position
 
+        self.robot.angle_vector(ri.angle_vector())
         time.sleep(3)
         self.reset_mannequin()
 

--- a/scripts/pr2/mannequine.py
+++ b/scripts/pr2/mannequine.py
@@ -73,7 +73,7 @@ class Mannequin(object):
         self.enable_mirror = mirror
         self.use_home_position = use_home_position
 
-        self.robot.angle_vector(ri.angle_vector())
+        self.robot.angle_vector(self.ri.angle_vector())
         time.sleep(3)
         self.reset_mannequin()
 

--- a/scripts/pr2/reset_to_home.py
+++ b/scripts/pr2/reset_to_home.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
 
     robot = PR2()
     ri = PR2ROSRobotInterface(robot)
+    robot.angle_vector(ri.angle_vector())
 
     assert config.home_position is not None
 


### PR DESCRIPTION
Fixed the behavior of `scripts/pr2/reset_to_home.py` to relay the robot's init-pose when changing posture at the start of scikit-robot use. `scripts/pr2/mannequine.py` may also be fixed.