### PR TITLE
Add terminate with TerminateFlag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ rosrun mohou_ros reset_to_home.py -pn {your_project_name}
 ```
 
 #### execution using the trained policy
-Without the `--force` argument, the actual robot will not move, i.e., it will dryrun.
+Without the `--force` argument, the real robot will not move, i.e., it will dryrun. The `--terminate` argument can be used to automatically terminate the program if the value of `TerminateFlag` exceeds the threshold value. The threshold value can be set with `-tt` argument.
 ```
 rosrun mohou_ros execute_pr2.py -pn {your_project_name} --force
 ```

--- a/mohou_ros_utils/executor.py
+++ b/mohou_ros_utils/executor.py
@@ -88,6 +88,7 @@ class ExecutorBase(ABC):
     debug_images_seq: List[DebugImages]
     edict_seq: List[ElementDict]
     is_terminatable: bool
+    terminate_threthold: float
     str_time_postfix: str
 
     rgb_topic_name: str
@@ -103,7 +104,9 @@ class ExecutorBase(ABC):
 
     current_av: Optional[AngleVector] = None
 
-    def __init__(self, project_path: Path, dryrun=True, save_rosbag=True) -> None:
+    def __init__(
+        self, project_path: Path, dryrun=True, save_rosbag=True, terminate_threthold: float = 0.98
+    ) -> None:
         propagator: Propagator = create_default_propagator(project_path, Propagator)
 
         ae_type = auto_detect_autoencoder_type(project_path)
@@ -122,6 +125,7 @@ class ExecutorBase(ABC):
 
         self._post_init()
         self.dryrun = dryrun
+        self.terminate_threthold = terminate_threthold
 
         # start!
         self.debug_images_seq = []
@@ -181,7 +185,7 @@ class ExecutorBase(ABC):
         self.propagator.feed(edict_current)
 
         edict_next = self.propagator.predict(1)[0]
-        self.is_terminatable = edict_next[TerminateFlag].numpy().item() > 0.98
+        self.is_terminatable = edict_next[TerminateFlag].numpy().item() > self.terminate_threthold
 
         # save debug infos
         robot_camera_view = edict_current[RGBImage]

--- a/mohou_ros_utils/pr2/executor.py
+++ b/mohou_ros_utils/pr2/executor.py
@@ -2,7 +2,13 @@
 
 import numpy as np
 import rospy
-from mohou.types import AngleVector, AnotherGripperState, ElementDict, GripperState
+from mohou.types import (
+    AngleVector,
+    AnotherGripperState,
+    ElementDict,
+    GripperState,
+    TerminateFlag,
+)
 from skrobot.interfaces.ros import PR2ROSRobotInterface  # type: ignore
 from skrobot.model import Joint
 from skrobot.models import PR2
@@ -47,6 +53,9 @@ class SkrobotPR2Executor(ExecutorBase):
         av_current = edict_current[AngleVector]
         av_next = edict_next[AngleVector]
         rospy.loginfo("current_av {}, next_av {}".format(av_current.numpy(), av_next.numpy()))
+
+        tf_next = edict_next[TerminateFlag]
+        rospy.loginfo("TerminateFlag {}".format(tf_next.numpy()))
 
         for angle, joint_name in zip(av_next.numpy(), self.control_joint_names):
             self.robot_model.__dict__[joint_name].joint_angle(angle)

--- a/scripts/pr2/execute_pr2.py
+++ b/scripts/pr2/execute_pr2.py
@@ -18,12 +18,16 @@ if __name__ == "__main__":
     parser.add_argument("-t", type=float, default=300, help="time out")
     parser.add_argument("--force", action="store_true", help="disable dry option")
     parser.add_argument("--roseus", action="store_true", help="command via roseus")
+    parser.add_argument("--terminate", action="store_true", help="terminate using terminate flag")
+    parser.add_argument("-tt", type=float, default=0.8, help="threthold of terminate flag")
 
     args = parser.parse_args()
     project_name: Optional[str] = args.pn
     time_out: float = args.t
     force: bool = args.force
     roseus: bool = args.roseus
+    use_terminate: bool = args.terminate
+    threshold_threshold: float = args.tt
 
     rospy.init_node("executor", disable_signals=True)
     project_path = get_project_path(project_name)
@@ -31,7 +35,9 @@ if __name__ == "__main__":
     if roseus:
         executor: ExecutorBase = EusPR2Executor(project_path, dryrun=(not force))
     else:
-        executor = SkrobotPR2Executor(project_path, dryrun=(not force))
+        executor = SkrobotPR2Executor(
+            project_path, dryrun=(not force), terminate_threthold=threshold_threshold
+        )
 
     executor.run()
 
@@ -42,6 +48,10 @@ if __name__ == "__main__":
             elapsed = time.time() - ts
             if elapsed > time_out:
                 rospy.loginfo("finish")
+                executor.terminate()
+                break
+            elif use_terminate and executor.is_terminatable:
+                rospy.loginfo("terminate")
                 executor.terminate()
                 break
     except KeyboardInterrupt:


### PR DESCRIPTION
Added the ability to terminate skill execution when `TerminateFlag` reaches or exceeds a threshold value and the skill side is determined to be terminated.  
Add `terminate_threthold` argument and slot, and implement using `is_terminatable`, which was originally implemented in ExecutorBase.  

I haven't checked it on the real robot yet, so I will check it tomorrow after the test passes.