### PR TITLE
feat: check if joint angle consistency with home position

### DIFF
--- a/mohou_ros_utils/pr2/executor.py
+++ b/mohou_ros_utils/pr2/executor.py
@@ -83,10 +83,22 @@ class SkrobotPR2Executor(ExecutorBase):
 
         error_detail_list = []
 
+        exclude_keywords = ["gripper", "laser_tilt", "caster", "motor_screw"]
+
+        def is_skippable(joint_name: str) -> bool:
+            # TODO: this is truly adhoc approach
+            for kw in exclude_keywords:
+                if kw in joint_name:
+                    return True
+            return False
+
         for joint_name, angle_desired in home_position_dict.items():
 
             is_controlling_joint = joint_name in self.control_joint_names
             if is_controlling_joint:
+                continue
+
+            if is_skippable(joint_name):
                 continue
 
             model_of_ri = self.robot_interface.robot

--- a/rostest/run_executor.py
+++ b/rostest/run_executor.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import shutil
 import subprocess
 import unittest
 from pathlib import Path
@@ -27,9 +28,19 @@ class TestNode(unittest.TestCase):
         subprocess.run(cmd, shell=True)
 
     def _test_executor(self):
+
+        # clean up execution result directory
+        exec_debug_dir_path = get_subpath(self.project_path, RelativeName.exec_debug)
+        shutil.rmtree(exec_debug_dir_path)
+        exec_debug_dir_path.mkdir(exist_ok=True)
+
+        # test start
+        cmd = "rosrun mohou_ros reset_to_home.py -pn {}".format(self.project_name)
+        self._run_command(cmd)
+
         cmd = "rosrun mohou_ros execute_pr2.py -pn {} --force -t 10".format(self.project_name)
         self._run_command(cmd)
-        exec_debug_dir_path = get_subpath(self.project_path, RelativeName.exec_debug)
+
         file_path_list = list(exec_debug_dir_path.iterdir())
 
         rosbag_path_list = [p for p in file_path_list if p.name.endswith(".bag")]


### PR DESCRIPTION
Check if joints except controlling joints are consistent with the home position angles. 
If not consistent, the program terminate with the following error message. 
```
[ERROR] [1662313010.220017, 7.151000]: 3 non-controlling joint angles are not consistent with home position.
{'joint_name': 'head_pan_joint', 'angle': -0.00015167343818500711, 'angle_desired': 0.4, 'error': -0.40015167343818503, 'threshold': 0.03490658503988659}
{'joint_name': 'l_elbow_flex_joint', 'angle': -0.27438454705988224, 'angle_desired': -0.22562075402918058, 'error': -0.04876379303070166, 'threshold': 0.03490658503988659}
{'joint_name': 'l_wrist_flex_joint', 'angle': -0.38193070820598507, 'angle_desired': -0.2676547423722404, 'error': -0.11427596583374466, 'threshold': 0.03490658503988659}

```